### PR TITLE
Reward computation during log_prob

### DIFF
--- a/scripts/model_merger.py
+++ b/scripts/model_merger.py
@@ -28,7 +28,6 @@ try:
 except ImportError:
     from torch.distributed._tensor import DTensor
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument('--backend', type=str, required=True, help="The backend of the model", choices=["fsdp", "megatron"])
 parser.add_argument('--tie-word-embedding', action='store_true', help="Whether to tie word embedding weights")

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -171,6 +171,7 @@ reward_model:
   use_dynamic_bsz: ${critic.use_dynamic_bsz}
   forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
   reward_manager: naive
+  reward_manager_during_log_prob: False # call the reward manager on CPU, during log_prob
 
 custom_reward_function:
   path: null

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -194,8 +194,11 @@ trainer:
   total_training_steps: null
   project_name: verl_examples
   experiment_name: gsm8k
-  logger: [ 'console', 'wandb' ]
-  log_val_generations: 0
+  logger: [ 'console', 'database' ]
+  validation_data_dir: ~/validation_data # directory for logging the validation data
+  log_val_generations: 1 # 0 for no logging, any other value logs the validation data
+  rollout_data_dir: ~/rollout_data # directory for logging the rollout data
+  log_rollout_generations: 1 # 0 for no logging, any other value logs the rollout data
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -14,44 +14,11 @@
 """
 Note that we don't combine the main with ray_trainer as ray_trainer is used by other main.
 """
-from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer, load_reward_manager
 
 import os
 import ray
 import hydra
-
-
-def get_custom_reward_fn(config):
-    import importlib.util, sys
-    reward_fn_config = config.get("custom_reward_function") or {}
-    file_path = reward_fn_config.get("path")
-    if not file_path:
-        return None
-
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
-
-    spec = importlib.util.spec_from_file_location("custom_module", file_path)
-    module = importlib.util.module_from_spec(spec)
-    try:
-        sys.modules["custom_module"] = module
-        spec.loader.exec_module(module)
-    except Exception as e:
-        raise RuntimeError(f"Error loading module from '{file_path}': {e}")
-
-    function_name = reward_fn_config.get("name")
-    if not hasattr(module, function_name):
-        raise AttributeError(f"Reward function '{function_name}' not found in '{file_path}'.")
-
-    print(f"using customized reward function '{function_name}' from '{file_path}'")
-    raw_fn = getattr(module, function_name)
-
-    reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))
-
-    def wrapped_fn(*args, **kwargs):
-        return raw_fn(*args, **kwargs, **reward_kwargs)
-
-    return wrapped_fn
 
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
@@ -63,6 +30,7 @@ def run_ppo(config) -> None:
     # TODO(linjunrong.ocss884): this ENV is left for resolving SGLang conflict with ray devices
     # isolation, will solve in the future
     os.environ["ENSURE_CUDA_VISIBLE_DEVICES"] = os.environ.get('CUDA_VISIBLE_DEVICES', '')
+
     if not ray.is_initialized():
         # this is for local ray cluster
         ray.init(runtime_env={
@@ -70,7 +38,7 @@ def run_ppo(config) -> None:
                 'TOKENIZERS_PARALLELISM': 'true',
                 'NCCL_DEBUG': 'WARN',
                 'VLLM_LOGGING_LEVEL': 'WARN'
-            }
+            },
         })
 
     runner = TaskRunner.remote()
@@ -150,36 +118,8 @@ class TaskRunner:
             role_worker_mapping[Role.RefPolicy] = ray.remote(ActorRolloutRefWorker)
             mapping[Role.RefPolicy] = global_pool_id
 
-        reward_manager_name = config.reward_model.get("reward_manager", "naive")
-        if reward_manager_name == 'naive':
-            from verl.workers.reward_manager import NaiveRewardManager
-            reward_manager_cls = NaiveRewardManager
-        elif reward_manager_name == 'prime':
-            from verl.workers.reward_manager import PrimeRewardManager
-            reward_manager_cls = PrimeRewardManager
-        elif reward_manager_name == 'batch':
-            from verl.workers.reward_manager import BatchRewardManager
-            reward_manager_cls = BatchRewardManager
-        elif reward_manager_name == 'dapo':
-            from verl.workers.reward_manager import DAPORewardManager
-            reward_manager_cls = DAPORewardManager
-        else:
-
-            raise NotImplementedError
-
-        compute_score = get_custom_reward_fn(config)
-        reward_kwargs = dict(config.reward_model.get("reward_kwargs", {}))
-        reward_fn = reward_manager_cls(tokenizer=tokenizer,
-                                       num_examine=0,
-                                       compute_score=compute_score,
-                                       reward_fn_key=config.data.reward_fn_key,
-                                       **reward_kwargs)
-
-        # Note that we always use function-based RM for validation
-        val_reward_fn = reward_manager_cls(tokenizer=tokenizer,
-                                           num_examine=1,
-                                           compute_score=compute_score,
-                                           reward_fn_key=config.data.reward_fn_key)
+        reward_fn = load_reward_manager(config, tokenizer, num_examine=0, take_reward_kwargs=True)
+        val_reward_fn = load_reward_manager(config, tokenizer, num_examine=1, take_reward_kwargs=False)
         resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
 
         trainer = RayPPOTrainer(config=config,

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -30,7 +30,6 @@ def run_ppo(config) -> None:
     # TODO(linjunrong.ocss884): this ENV is left for resolving SGLang conflict with ray devices
     # isolation, will solve in the future
     os.environ["ENSURE_CUDA_VISIBLE_DEVICES"] = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-
     if not ray.is_initialized():
         # this is for local ray cluster
         ray.init(runtime_env={
@@ -38,7 +37,7 @@ def run_ppo(config) -> None:
                 'TOKENIZERS_PARALLELISM': 'true',
                 'NCCL_DEBUG': 'WARN',
                 'VLLM_LOGGING_LEVEL': 'WARN'
-            },
+            }
         })
 
     runner = TaskRunner.remote()

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1007,7 +1007,7 @@ class RayPPOTrainer(object):
                         if self.config.reward_model.reward_manager_during_log_prob:
                             future_reward = compute_reward_asyn.remote(batch, self.config, self.tokenizer)
                         else:
-                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.rm_wg)
+                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 
 
                     # recompute old_log_probs

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -237,6 +237,83 @@ def _timer(name: str, timing_raw: Dict[str, float]):
     timing_raw[name] = timer.last
 
 
+def get_custom_reward_fn(config):
+    import importlib.util, sys
+    reward_fn_config = config.get("custom_reward_function") or {}
+    file_path = reward_fn_config.get("path")
+    if not file_path:
+        return None
+
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
+
+    spec = importlib.util.spec_from_file_location("custom_module", file_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        sys.modules["custom_module"] = module
+        spec.loader.exec_module(module)
+    except Exception as e:
+        raise RuntimeError(f"Error loading module from '{file_path}': {e}")
+
+    function_name = reward_fn_config.get("name")
+    if not hasattr(module, function_name):
+        raise AttributeError(f"Reward function '{function_name}' not found in '{file_path}'.")
+
+    print(f"using customized reward function '{function_name}' from '{file_path}'")
+    raw_fn = getattr(module, function_name)
+
+    reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))
+
+    def wrapped_fn(*args, **kwargs):
+        return raw_fn(*args, **kwargs, **reward_kwargs)
+
+    return wrapped_fn
+
+
+def load_reward_manager(config, tokenizer, num_examine, take_reward_kwargs):
+    reward_manager_name = config.reward_model.get("reward_manager", "naive")
+    if reward_manager_name == 'naive':
+        from verl.workers.reward_manager import NaiveRewardManager
+        reward_manager_cls = NaiveRewardManager
+    elif reward_manager_name == 'prime':
+        from verl.workers.reward_manager import PrimeRewardManager
+        reward_manager_cls = PrimeRewardManager
+    elif reward_manager_name == 'batch':
+        from verl.workers.reward_manager import BatchRewardManager
+        reward_manager_cls = BatchRewardManager
+    elif reward_manager_name == 'dapo':
+        from verl.workers.reward_manager import DAPORewardManager
+        reward_manager_cls = DAPORewardManager
+    else:
+        raise NotImplementedError
+
+    compute_score = get_custom_reward_fn(config)
+    reward_kwargs = {}
+    if take_reward_kwargs:
+        reward_kwargs = dict(config.reward_model.get("reward_kwargs", {}))
+    return reward_manager_cls(tokenizer=tokenizer,
+                               num_examine=num_examine,
+                               compute_score=compute_score,
+                               reward_fn_key=config.data.reward_fn_key,
+                               **reward_kwargs)
+
+
+@ray.remote(num_cpus=1)
+def compute_reward_fn(data: DataProto, config, tokenizer):
+    reward_fn = load_reward_manager(config, tokenizer, num_examine=0, take_reward_kwargs=True)
+
+    try:
+        reward_result = reward_fn(data, return_dict=True)
+        reward_tensor = reward_result['reward_tensor']
+        reward_extra_infos_dict = reward_result['reward_extra_info']
+    except Exception as e:
+        print(f'Error in reward_fn: {e}')
+        reward_tensor = reward_fn(data)
+        reward_extra_infos_dict = {}
+
+    return reward_tensor, reward_extra_infos_dict
+
+
 class RayPPOTrainer(object):
     """
     Note that this trainer runs on the driver process on a single CPU/GPU node.
@@ -906,6 +983,14 @@ class RayPPOTrainer(object):
                     # compute global_valid tokens
                     batch.meta_info['global_token_num'] = torch.sum(batch.batch['attention_mask'], dim=-1).tolist()
 
+                    with _timer('reward', timing_raw):
+                        # compute reward model score
+                        if self.use_rm:
+                            reward_tensor = self.rm_wg.compute_rm_score(batch)
+                            batch = batch.union(reward_tensor)
+
+                        future_reward = compute_reward_fn.remote(batch, self.config, self.tokenizer)
+
                     # recompute old_log_probs
                     with _timer('old_log_prob', timing_raw):
                         old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
@@ -924,25 +1009,9 @@ class RayPPOTrainer(object):
                             batch = batch.union(values)
 
                     with _timer('adv', timing_raw):
-                        # compute scores. Support both model and function-based.
-                        # We first compute the scores using reward model. Then, we call reward_fn to combine
-                        # the results from reward model and rule-based results.
-                        if self.use_rm:
-                            # we first compute reward model score
-                            reward_tensor = self.rm_wg.compute_rm_score(batch)
-                            batch = batch.union(reward_tensor)
-
                         # we combine with rule-based rm
                         reward_extra_infos_dict: dict[str, list]
-                        try:
-                            reward_result = self.reward_fn(batch, return_dict=True)
-                            reward_tensor = reward_result['reward_tensor']
-                            reward_extra_infos_dict = reward_result['reward_extra_info']
-                        except Exception as e:
-                            print(f'Error in reward_fn: {e}')
-                            reward_tensor = self.reward_fn(batch)
-                            reward_extra_infos_dict = {}
-
+                        reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
                         batch.batch['token_level_scores'] = reward_tensor
 
                         if self.config.trainer.log_rollout_generations > 0:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -298,10 +298,15 @@ def load_reward_manager(config, tokenizer, num_examine, take_reward_kwargs):
                               **reward_kwargs)
 
 
-@ray.remote(num_cpus=1)
-def compute_reward_fn(data: DataProto, config, tokenizer):
-    reward_fn = load_reward_manager(config, tokenizer, num_examine=0, take_reward_kwargs=True)
-
+def compute_reward(data: DataProto, reward_fn):
+    """
+    Compute reward for a batch of data.
+    Args:
+        data: DataProto object containing the input data.
+        reward_fn: Reward function to compute the reward.
+    Returns:
+        Tuple of reward tensor and extra info dictionary.
+    """
     try:
         reward_result = reward_fn(data, return_dict=True)
         reward_tensor = reward_result['reward_tensor']
@@ -312,6 +317,16 @@ def compute_reward_fn(data: DataProto, config, tokenizer):
         reward_extra_infos_dict = {}
 
     return reward_tensor, reward_extra_infos_dict
+
+
+@ray.remote(num_cpus=1)
+def compute_reward_asyn(data: DataProto, config, tokenizer):
+    """
+    Load the reward manager and compute the reward for a batch of data.
+    This is meant to be run in a separate Ray worker.
+    """
+    reward_fn = load_reward_manager(config, tokenizer, num_examine=0, take_reward_kwargs=True)
+    return compute_reward(data, reward_fn)
 
 
 class RayPPOTrainer(object):
@@ -989,7 +1004,11 @@ class RayPPOTrainer(object):
                             reward_tensor = self.rm_wg.compute_rm_score(batch)
                             batch = batch.union(reward_tensor)
 
-                        future_reward = compute_reward_fn.remote(batch, self.config, self.tokenizer)
+                        if self.config.reward_model.reward_manager_during_log_prob:
+                            future_reward = compute_reward_asyn.remote(batch, self.config, self.tokenizer)
+                        else:
+                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.rm_wg)
+
 
                     # recompute old_log_probs
                     with _timer('old_log_prob', timing_raw):
@@ -1011,7 +1030,8 @@ class RayPPOTrainer(object):
                     with _timer('adv', timing_raw):
                         # we combine with rule-based rm
                         reward_extra_infos_dict: dict[str, list]
-                        reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
+                        if self.config.reward_model.reward_manager_during_log_prob:
+                            reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
                         batch.batch['token_level_scores'] = reward_tensor
 
                         if self.config.trainer.log_rollout_generations > 0:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -292,10 +292,10 @@ def load_reward_manager(config, tokenizer, num_examine, take_reward_kwargs):
     if take_reward_kwargs:
         reward_kwargs = dict(config.reward_model.get("reward_kwargs", {}))
     return reward_manager_cls(tokenizer=tokenizer,
-                               num_examine=num_examine,
-                               compute_score=compute_score,
-                               reward_fn_key=config.data.reward_fn_key,
-                               **reward_kwargs)
+                              num_examine=num_examine,
+                              compute_score=compute_score,
+                              reward_fn_key=config.data.reward_fn_key,
+                              **reward_kwargs)
 
 
 @ray.remote(num_cpus=1)

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -19,10 +19,11 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from typing import List, Union, Dict, Any
+import os
 
 
 class Tracking(object):
-    supported_backend = ["wandb", "mlflow", "swanlab", "vemlp_wandb", "tensorboard", "console"]
+    supported_backend = ["wandb", "mlflow", "swanlab", "vemlp_wandb", "tensorboard", "console", "database"]
 
     def __init__(self, project_name, experiment_name, default_backend: Union[str, List[str]] = 'console', config=None):
         if isinstance(default_backend, str):
@@ -179,13 +180,17 @@ def _flatten_dict(raw: Dict[str, Any], *, sep: str) -> Dict[str, Any]:
 @dataclasses.dataclass
 class ValidationGenerationsLogger:
 
-    def log(self, loggers, samples, step):
+    def log(self, loggers, samples, step, epoch=None, data_dir=None):
         if 'wandb' in loggers:
             self.log_generations_to_wandb(samples, step)
         if 'swanlab' in loggers:
             self.log_generations_to_swanlab(samples, step)
         if 'mlflow' in loggers:
             self.log_generations_to_mlflow(samples, step)
+        if 'database' in loggers:
+            if data_dir is None:
+                raise ValueError("data_dir must be provided for database logging")
+            self.log_generations_to_database(samples, step, epoch, data_dir)
 
     def log_generations_to_wandb(self, samples, step):
         """Log samples to wandb as a table"""
@@ -255,3 +260,135 @@ class ValidationGenerationsLogger:
                 mlflow.log_artifact(validation_gen_step_file)
         except Exception as e:
             print(f"WARNING: save validation generation file to mlflow failed with error {e}")
+
+    def log_generations_to_database(self, samples, step, epoch, data_dir):
+        """Log the rollout samples to a parquet file at data_dir"""
+        import os
+        from datasets import Dataset
+
+        num_samples = len(samples)
+
+        # Create a Dataset from the samples
+        data = {
+            "input": [sample[0] for sample in samples],
+            "output": [sample[1] for sample in samples],
+            "score": [sample[2] for sample in samples],
+            "epoch": [epoch] * num_samples,
+            "step": [step] * num_samples
+        }
+        dataset = Dataset.from_dict(data)
+
+        # Define the path for the parquet file
+        file_path = os.path.join(data_dir, f"validation_step_{step}.parquet")
+
+        # Write the Dataset to a parquet file
+        dataset.to_parquet(file_path)
+
+
+@dataclasses.dataclass
+class RolloutLogger:
+
+    def log(self, loggers, samples, step, epoch=None, data_dir=None):
+        if 'wandb' in loggers:
+            self.log_generations_to_wandb(samples, step)
+        if 'swanlab' in loggers:
+            self.log_generations_to_swanlab(samples, step)
+        if 'mlflow' in loggers:
+            self.log_generations_to_mlflow(samples, step)
+        if 'database' in loggers:
+            if data_dir is None:
+                raise ValueError("Data directory must be provided for database logging")
+            if epoch is None:
+                raise ValueError("Epoch number be provided for database logging")
+            self.log_generations_to_database(samples, step, epoch, data_dir)
+
+    def log_generations_to_wandb(self, samples, step):
+        """Log samples to wandb as a table"""
+        import wandb
+
+        # Create column names for all samples
+        columns = ["step"] + sum([[f"input_{i+1}", f"output_{i+1}", f"score_{i+1}"] for i in range(len(samples))], [])
+
+        if not hasattr(self, 'rollout_data_table'):
+            # Initialize the table on first call
+            self.rollout_data_table = wandb.Table(columns=columns)
+
+        # Create a new table with same columns and existing data
+        # Workaround for https://github.com/wandb/wandb/issues/2981#issuecomment-1997445737
+        new_table = wandb.Table(columns=columns, data=self.rollout_data_table.data)
+
+        # Add new row with all data
+        row_data = []
+        row_data.append(step)
+        for sample in samples:
+            row_data.extend(sample)
+
+        new_table.add_data(*row_data)
+
+        # Update reference and log
+        wandb.log({"rollout/generations": new_table}, step=step)
+        self.rollout_data_table = new_table
+
+    def log_generations_to_swanlab(self, samples, step):
+        """Log samples to swanlab as text"""
+        import swanlab
+
+        swanlab_text_list = []
+        for i, sample in enumerate(samples):
+            row_text = f"""
+            input: {sample[0]}
+            
+            ---
+            
+            output: {sample[1]}
+            
+            ---
+            
+            score: {sample[2]}
+            """
+            swanlab_text_list.append(swanlab.Text(row_text, caption=f"sample {i+1}"))
+
+        # Log to swanlab
+        swanlab.log({"rollout/generations": swanlab_text_list}, step=step)
+
+    def log_generations_to_mlflow(self, samples, step):
+        """Log validation generation to mlflow as artifacts"""
+        #https://mlflow.org/docs/latest/api_reference/python_api/mlflow.html?highlight=log_artifact#mlflow.log_artifact
+
+        import mlflow
+        import tempfile
+        import json
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                rollout_data_file = Path(tmp_dir, f"rollout_{step}.json")
+                row_data = []
+                for sample in samples:
+                    data = {"input": sample[0], "output": sample[1], "score": sample[2]}
+                    row_data.append(data)
+                with open(rollout_data_file, "w") as file:
+                    json.dump(row_data, file)
+                mlflow.log_artifact(rollout_data_file)
+        except Exception as e:
+            print(f"WARNING: save validation generation file to mlflow failed with error {e}")
+
+    def log_generations_to_database(self, samples, step, epoch, data_dir):
+        """Log the rollout samples to a parquet file at data_dir"""
+        import os
+        from datasets import Dataset
+
+        num_samples = len(samples)
+        # Create a Dataset from the samples
+        data = {
+            "input": [sample[0] for sample in samples],
+            "output": [sample[1] for sample in samples],
+            "score": [sample[2] for sample in samples],
+            "epoch": [epoch] * num_samples,
+            "step": [step] * num_samples
+        }
+        dataset = Dataset.from_dict(data)
+
+        # Define the path for the parquet file
+        file_path = os.path.join(data_dir, f"rollout_step_{step}.parquet")
+
+        # Write the Dataset to a parquet file
+        dataset.to_parquet(file_path)


### PR DESCRIPTION
Add a argument to compute the renforcement learning reward on another CPU worker, just after the rollout during the log_prob to avoid wasting GPU compute.

Before / After on 1.5B model with 1024 batch size:

<img width="608" alt="image" src="https://github.com/user-attachments/assets/c100d9c1-0c43-4446-a8cd-9bcd1a36b02d" />

Note:
- We have to load the custom reward on the worker. It is difficult to give to a ray worker a module loaded using `importlib.util.spec_from_file_location`.