### PR TITLE
length penaly in reward function

### DIFF
--- a/verl/trainer/config/generation.yaml
+++ b/verl/trainer/config/generation.yaml
@@ -40,6 +40,11 @@ rollout:
   disable_log_stats: True
   enable_chunked_prefill: True
   n: 1
+  length_penalty:
+    enabled: False  # Set to True to enable length penalty during generation
+    alpha: 0.0      # Alpha parameter: positive favors longer sequences, negative favors shorter
+    min_length: 0   # Minimum sequence length before applying penalty
+    max_length: null  # Maximum sequence length (null means no maximum)
 actor:
   strategy: fsdp  # This is for backward-compatibility
   ulysses_sequence_parallel_size: 1 # sp size

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -203,6 +203,11 @@ reward_model:
   use_dynamic_bsz: ${critic.use_dynamic_bsz}
   max_length: null
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
+  length_penalty:   
+    enabled: False  # Set to True to enable length penalty
+    alpha: 0.0      # Alpha parameter: positive favors longer sequences, negative favors shorter
+    min_length: 0   # Minimum sequence length before applying penalty
+    max_length: null  # Maximum sequence length (null means no maximum)
 
 custom_reward_function:
   path: null

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -183,6 +183,11 @@ reward_model:
   forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
   reward_manager: naive
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
+  length_penalty:   
+    enabled: False  # Set to True to enable length penalty
+    alpha: 0.0      # Alpha parameter: positive favors longer sequences, negative favors shorter
+    min_length: 0   # Minimum sequence length before applying penalty
+    max_length: null  # Maximum sequence length (null means no maximum)
 
 custom_reward_function:
   path: null

--- a/verl/utils/length_penalty.py
+++ b/verl/utils/length_penalty.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Individual Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+def compute_length_penalty(sequence_lengths, alpha=0.0, min_length=0, max_length=None):
+    """
+    Compute length penalty for sequence generation.
+    
+    Args:
+        sequence_lengths: Tensor of shape [batch_size] containing sequence lengths
+        alpha: Float controlling the strength and direction of the penalty:
+               - alpha > 0: Favor longer sequences
+               - alpha < 0: Favor shorter sequences
+               - alpha = 0: No length penalty
+        min_length: Minimum sequence length before applying penalty (no penalty below this)
+        max_length: Maximum sequence length (sequences longer than this get max penalty)
+    
+    Returns:
+        Tensor of shape [batch_size] containing length penalties to be applied to rewards
+    """
+    if alpha == 0.0:
+        return torch.ones_like(sequence_lengths, dtype=torch.float32)
+    
+    effective_lengths = sequence_lengths.clone().float()
+    
+    if min_length > 0:
+        effective_lengths = torch.maximum(effective_lengths - min_length, 
+                                         torch.zeros_like(effective_lengths))
+    
+    if max_length is not None:
+        effective_lengths = torch.minimum(effective_lengths, 
+                                         torch.ones_like(effective_lengths) * (max_length - min_length))
+    
+    # Calculate penalty using the standard formula: ((5 + length)/6)^alpha
+    # This is similar to the formula used in Google Neural Machine Translation (GNMT) paper
+    penalty = ((5.0 + effective_lengths) / 6.0) ** alpha
+    
+    return penalty
+
+def apply_length_penalty(rewards, sequence_lengths, **kwargs):
+    """
+    Apply length penalty to rewards.
+    
+    Args:
+        rewards: Tensor of shape [batch_size] containing the original rewards
+        sequence_lengths: Tensor of shape [batch_size] containing sequence lengths
+        **kwargs: Parameters for compute_length_penalty
+    
+    Returns:
+        Tensor of shape [batch_size] with length-penalized rewards
+    """
+    length_penalties = compute_length_penalty(sequence_lengths, **kwargs)
+    return rewards * length_penalties

--- a/verl/workers/reward_model/base.py
+++ b/verl/workers/reward_model/base.py
@@ -16,13 +16,21 @@ The base class for reward model
 """
 
 from abc import ABC, abstractmethod
+import torch
 
 from verl import DataProto
+from verl.utils.length_penalty import apply_length_penalty
 
 
 class BasePPORewardModel(ABC):
     def __init__(self, config):
         self.config = config
+        # Initialize length penalty parameters
+        self.length_penalty_config = config.reward_model.get("length_penalty", {})
+        self.use_length_penalty = self.length_penalty_config.get("enabled", False)
+        self.length_penalty_alpha = self.length_penalty_config.get("alpha", 0.0)
+        self.length_penalty_min_length = self.length_penalty_config.get("min_length", 0)
+        self.length_penalty_max_length = self.length_penalty_config.get("max_length", None)
 
     @abstractmethod
     def compute_reward(self, data: DataProto) -> DataProto:
@@ -42,3 +50,47 @@ class BasePPORewardModel(ABC):
 
         """
         pass
+
+    def apply_length_penalty(self, rewards, sequence_lengths):
+        """
+        Apply length penalty to the rewards if enabled.
+        
+        Args:
+            rewards: Tensor of shape [batch_size] containing rewards
+            sequence_lengths: Tensor of shape [batch_size] containing sequence lengths
+            
+        Returns:
+            Tensor of shape [batch_size] with potentially modified rewards
+        """
+        if not self.use_length_penalty:
+            return rewards
+            
+        return apply_length_penalty(
+            rewards,
+            sequence_lengths,
+            alpha=self.length_penalty_alpha,
+            min_length=self.length_penalty_min_length,
+            max_length=self.length_penalty_max_length
+        )
+
+    def _get_sequence_lengths(self, data):
+        """
+        Extract response lengths from the data.
+        
+        Args:
+            data: DataProto object with input_ids and attention_mask
+            
+        Returns:
+            Tensor of shape [batch_size] containing sequence lengths
+        """
+        if "response_lengths" in data:
+            return data["response_lengths"]
+        
+        # If response_lengths not provided, try to compute from attention_mask
+        if "attention_mask" in data and "prompt_lengths" in data:
+            # Calculate response length by subtracting prompt length from total length
+            total_lengths = torch.sum(data["attention_mask"], dim=1)
+            prompt_lengths = data["prompt_lengths"]
+            return total_lengths - prompt_lengths
+            
+        return None


### PR DESCRIPTION
The length penalty is calculated using the formula: ((5 + length) / 6) ^ alpha

This is based on the formula used in Google Neural Machine Translation paper [https://arxiv.org/pdf/1609.08144]
When alpha < 0, shorter sequences get higher rewards
When alpha > 0, longer sequences get higher rewards

Length penalties are applied to the final reward scores, after the primary reward calculation